### PR TITLE
Update dependencies needed for Android Studio 1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,13 +5,13 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
+        classpath 'com.android.tools.build:gradle:1.0.1'
     }
 }
 
 android {
     compileSdkVersion "Google Inc.:Glass Development Kit Preview:19"
-    buildToolsVersion "20.0.0"
+    buildToolsVersion "21.1.2"
 
     sourceSets {
         main {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Nov 18 11:35:55 EST 2014
+#Sun Mar 01 21:56:51 PST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
Updates Gradle to 2.2.1, Gradle Plugin to 1.0.1 (latest version, 1.1 does not work with Glass development), and build tools 21.1.2
